### PR TITLE
Added method getAppName() for Android & iOS

### DIFF
--- a/src/android/AppVersion.java
+++ b/src/android/AppVersion.java
@@ -24,11 +24,16 @@ public class AppVersion extends CordovaPlugin {
 				callbackContext.success(packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), 0).versionCode);
 			return true;
 			}
+			 if (action.equals("getAppName")) {
+                 PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+                 ApplicationInfo app = packageManager.getApplicationInfo(this.cordova.getActivity().getPackageName(), 0);
+                 callbackContext.success((String)packageManager.getApplicationLabel(app));
+                 return true;
+            }
 			return false;
 		} catch (NameNotFoundException e) {
 			callbackContext.success("N/A");
 			return true;
 		}
 	}
-
 }

--- a/src/android/AppVersion.java
+++ b/src/android/AppVersion.java
@@ -5,7 +5,7 @@ import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.PackageManager;
 

--- a/src/android/AppVersion.java
+++ b/src/android/AppVersion.java
@@ -24,6 +24,10 @@ public class AppVersion extends CordovaPlugin {
 				callbackContext.success(packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), 0).versionCode);
 			return true;
 			}
+			if (action.equals("getPackageName")) {
+            	callbackContext.success(this.cordova.getActivity().getPackageName());
+            	return true;
+            }
 			 if (action.equals("getAppName")) {
                  PackageManager packageManager = this.cordova.getActivity().getPackageManager();
                  ApplicationInfo app = packageManager.getApplicationInfo(this.cordova.getActivity().getPackageName(), 0);

--- a/src/ios/AppVersion.h
+++ b/src/ios/AppVersion.h
@@ -6,6 +6,8 @@
 
 - (void)getVersionCode:(CDVInvokedUrlCommand*)command;
 
+- (void)getPackageName:(CDVInvokedUrlCommand*)command;
+
 - (void)getAppName:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/AppVersion.h
+++ b/src/ios/AppVersion.h
@@ -6,4 +6,6 @@
 
 - (void)getVersionCode:(CDVInvokedUrlCommand*)command;
 
+- (void)getAppName:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -1,31 +1,39 @@
 #import "AppVersion.h"
-#import <Cordova/CDVPluginResult.h>
+#import < Cordova / CDVPluginResult.h >
 
 @implementation AppVersion
 
-- (void)getVersionNumber:(CDVInvokedUrlCommand*)command
+    - (void)getVersionNumber : (CDVInvokedUrlCommand *)command
 {
-    NSString* callbackId = command.callbackId;
-    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    if (version == nil) {
-      NSLog(@"CFBundleShortVersionString was nil, attempting CFBundleVersion");
-      version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
-      if (version == nil) {
-        NSLog(@"CFBundleVersion was also nil, giving up");
-        // not calling error callback here to maintain backward compatibility
-      }
-    }
-
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:version];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+  NSString * callbackId = command.callbackId;
+  NSString * version =[[[NSBundle mainBundle]infoDictionary]objectForKey :@"CFBundleShortVersionString"];
+if (version == nil) {
+  NSLog(@"CFBundleShortVersionString was nil, attempting CFBundleVersion");
+version =[[[NSBundle mainBundle]infoDictionary]objectForKey :@"CFBundleVersion"];
+if (version == nil) {
+  NSLog(@"CFBundleVersion was also nil, giving up");
+// not calling error callback here to maintain backward compatibility
+}
 }
 
-- (void)getVersionCode:(CDVInvokedUrlCommand*)command
+CDVPluginResult * pluginResult =[CDVPluginResult resultWithStatus : CDVCommandStatus_OK messageAsString : version];
+[self.commandDelegate sendPluginResult : pluginResult callbackId : callbackId];
+}
+
+- (void)getVersionCode : (CDVInvokedUrlCommand *)command
 {
-    NSString* callbackId = command.callbackId;
-    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:version];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+  NSString * callbackId = command.callbackId;
+  NSString * version =[[[NSBundle mainBundle]infoDictionary]objectForKey :@"CFBundleVersion"];
+CDVPluginResult * pluginResult =[CDVPluginResult resultWithStatus : CDVCommandStatus_OK messageAsString : version];
+[self.commandDelegate sendPluginResult : pluginResult callbackId : callbackId];
+}
+
+- (void)getAppName : (CDVInvokedUrlCommand *)command
+{
+    NSString * callbackId = command.callbackId;
+    NSString * version =[[[NSBundle mainBundle]infoDictionary]objectForKey :@"CFBundleDisplayName"];
+    CDVPluginResult * pluginResult =[CDVPluginResult resultWithStatus : CDVCommandStatus_OK messageAsString : version];
+    [self.commandDelegate sendPluginResult : pluginResult callbackId : callbackId];
 }
 
 @end

--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -1,5 +1,5 @@
 #import "AppVersion.h"
-#import < Cordova / CDVPluginResult.h >
+#import <Cordova/CDVPluginResult.h>
 
 @implementation AppVersion
 

--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -36,4 +36,13 @@ CDVPluginResult * pluginResult =[CDVPluginResult resultWithStatus : CDVCommandSt
     [self.commandDelegate sendPluginResult : pluginResult callbackId : callbackId];
 }
 
+- (void)getPackageName:(CDVInvokedUrlCommand*)command
+{
+    NSString* callbackId = command.callbackId;
+    NSString* packageName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:packageName];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+}
+
+
 @end

--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -41,4 +41,9 @@ getAppVersion.getAppName = function (success, fail) {
     return getPromisedCordovaExec('getAppName', success, fail);
 };
 
+getAppVersion.getPackageName = function (success, fail) {
+      return getPromisedCordovaExec('getPackageName', success, fail);
+    };
+
+
 module.exports = getAppVersion;

--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -4,37 +4,41 @@
 
 // Returns a jQuery or AngularJS deferred object, or pass a success and fail callbacks if you don't want to use jQuery or AngularJS
 var getPromisedCordovaExec = function (command, success, fail) {
-  var toReturn, deferred, injector, $q;
-  if (success === undefined) {
-    if (window.jQuery) {
-      deferred = jQuery.Deferred();
-      toReturn = deferred;
-    } else if (window.angular) {
-      injector = angular.injector(["ng"]);
-      $q = injector.get("$q");
-      deferred = $q.defer();
-      toReturn = deferred.promise;
-    } else {
-      return console.error('AppVersion either needs a success callback, or jQuery/AngularJS defined for using promises');
+    var toReturn, deferred, injector, $q;
+    if (success === undefined) {
+        if (window.jQuery) {
+            deferred = jQuery.Deferred();
+            toReturn = deferred;
+        } else if (window.angular) {
+            injector = angular.injector(["ng"]);
+            $q = injector.get("$q");
+            deferred = $q.defer();
+            toReturn = deferred.promise;
+        } else {
+            return console.error('AppVersion either needs a success callback, or jQuery/AngularJS defined for using promises');
+        }
+        success = deferred.resolve;
+        fail = deferred.reject;
     }
-    success = deferred.resolve;
-    fail = deferred.reject;
-  }
-  // 5th param is NOT optional. must be at least empty array
-  cordova.exec(success, fail, "AppVersion", command, []);
-  return toReturn;
+    // 5th param is NOT optional. must be at least empty array
+    cordova.exec(success, fail, "AppVersion", command, []);
+    return toReturn;
 };
 
 var getAppVersion = function (success, fail) {
-  return getPromisedCordovaExec('getVersionNumber', success, fail);
+    return getPromisedCordovaExec('getVersionNumber', success, fail);
 };
 
 getAppVersion.getVersionNumber = function (success, fail) {
-  return getPromisedCordovaExec('getVersionNumber', success, fail);
+    return getPromisedCordovaExec('getVersionNumber', success, fail);
 };
 
 getAppVersion.getVersionCode = function (success, fail) {
-  return getPromisedCordovaExec('getVersionCode', success, fail);
+    return getPromisedCordovaExec('getVersionCode', success, fail);
+};
+
+getAppVersion.getAppName = function (success, fail) {
+    return getPromisedCordovaExec('getAppName', success, fail);
 };
 
 module.exports = getAppVersion;


### PR DESCRIPTION
I added `getAppName()` for Android & iOS

It will give the application name set on config.xml within the `<name></name>` tags

on Android is the value of `android:label` in the manifest file, on iOS the value of `CFBundleDisplayName` in info.plist
