### PR TITLE
Bump plugin.xml version number to match new tagged version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="uk.co.whiteoctober.cordova.appversion"
-    version="0.1.5">
+    version="0.1.7">
 
     <name>AppVersion</name>
     <description>


### PR DESCRIPTION
I bumped the version to 0.1.7 instead of 0.1.6 because you can't (properly) update tags. I suggest that you merge this pull request, tag that as 0.1.7, and delete tag 0.1.6.  

This may seem like a minor issue but does mess things up for anyone trying to correctly version control their plugins. 