### PR TITLE
WP8: getAppName() and getPackageName() implemented

### DIFF
--- a/src/wp8/AppVersion.cs
+++ b/src/wp8/AppVersion.cs
@@ -1,24 +1,53 @@
 using System;
-using System.Windows;
-using System.Windows.Navigation;
-using Microsoft.Phone.Controls;
+using System.Reflection;
+using System.Xml.Linq;
+using Windows.ApplicationModel;
 using WPCordovaClassLib.Cordova;
 using WPCordovaClassLib.Cordova.Commands;
-using WPCordovaClassLib.Cordova.JSON;
-using Windows.ApplicationModel;
-using System.Xml.Linq;
 
 namespace Cordova.Extension.Commands
 {
-    public class AppVersion : BaseCommand
-    {
-        public void getVersionNumber(string empty)
-        {
-            //Windows.ApplicationModel.Package.current.id.version is NOT working in Windows Phone 8
-            //Workaround based on http://stackoverflow.com/questions/14371275/how-can-i-get-my-windows-store-apps-title-and-version-info
-            String version= XDocument.Load("WMAppManifest.xml").Root.Element("App").Attribute("Version").Value;
+	public class AppVersion : BaseCommand
+	{
+		public void getVersionNumber(string empty)
+		{
+			string version;
+			if (Environment.OSVersion.Version.Major <= 8)
+			{
+				// Package.Current.Id is NOT working in Windows Phone 8
+				// Workaround based on http://stackoverflow.com/questions/14371275/how-can-i-get-my-windows-store-apps-title-and-version-info
+				version = XDocument.Load("WMAppManifest.xml").Root.Element("App").Attribute("Version").Value;
+			}
+			else
+			{
+				version = Package.Current.Id.Version.ToString();
+			}
 
-            this.DispatchCommandResult(new PluginResult(PluginResult.Status.OK, version));
-        }
-    }
+			this.DispatchCommandResult(new PluginResult(PluginResult.Status.OK, version));
+		}
+
+		public void getAppName(string empty)
+		{
+			string name;
+			if (Environment.OSVersion.Version.Major <= 8)
+			{
+				//Windows.ApplicationModel.Package.Current.Id is NOT working in Windows Phone 8
+				//Workaround based on http://stackoverflow.com/questions/14371275/how-can-i-get-my-windows-store-apps-title-and-version-info
+				name = XDocument.Load("WMAppManifest.xml").Root.Element("App").Attribute("Title").Value;
+			}
+			else
+			{
+				name = Package.Current.Id.Name;
+			}
+
+			this.DispatchCommandResult(new PluginResult(PluginResult.Status.OK, name));
+		}
+
+		public void getPackageName(string empty)
+		{
+			string package = Assembly.GetExecutingAssembly().GetName().Name;
+
+			this.DispatchCommandResult(new PluginResult(PluginResult.Status.OK, package));
+		}
+	}
 }


### PR DESCRIPTION
I added implementations for the methods getAppName() and getPackageName().

Additionally I added a check for the os version, in the hope that upcoming windows phone versions will support Package.Current.Id.