### PR TITLE
Implement getAppName, getPackageName and getVersionCode for Windows 8

### DIFF
--- a/src/windows8/AppVersionProxy.js
+++ b/src/windows8/AppVersionProxy.js
@@ -2,6 +2,18 @@ AppVersionProxy = {
   getVersionNumber: function (successCallback, failCallback, args) {
     var version = Windows.ApplicationModel.Package.current.id.version;
     successCallback([version.major, version.minor, version.build, version.revision].join('.'));
-  }  
+  },
+  getAppName: function (successCallback, failCallback, args) {
+    var name = Windows.ApplicationModel.Package.current.displayName;
+    successCallback(name);
+  },
+  getPackageName: function (successCallback, failCallback, args) {
+    var name = Windows.ApplicationModel.Package.current.id.name;
+    successCallback(name);
+  },
+  getVersionCode: function (successCallback, failCallback, args) {
+    var build = Windows.ApplicationModel.Package.current.id.version.build;
+    successCallback(build);
+  }
 };
 cordova.commandProxy.add("AppVersion", AppVersionProxy);


### PR DESCRIPTION
Add getAppName, getPackageName and getVersionCode for Windows 8.

Simplified #58 as a single commit that doesn't change indentation styles.