### PR TITLE
Package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cordova-plugin-app-version",
+  "version": "0.1.7",
+  "description": "Cordova plugin to return the version number of the current app",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/whiteoctober/cordova-plugin-app-version.git"
+  },
+  "keywords": [
+    "cordova",
+    "ecosystem:cordova",
+    "app",
+    "version",
+    "appversion",
+    "plugin"
+  ],
+  "author": "whiteoctober",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/whiteoctober/cordova-plugin-app-version/issues"
+  },
+  "homepage": "https://github.com/whiteoctober/cordova-plugin-app-version#readme"
+}


### PR DESCRIPTION
So I made a simple package.json for npm. 
I guess this closes #60 

I also published this to https://www.npmjs.com/package/cordova-plugin-app-version
If you (@whiteoctober) want to get that repo, just say so and I'll transfer it.

Maybe cordova-plugin-app-version isn't the best name, since there's already a [cordova-plugin-appversion](https://github.com/Rareloop/cordova-plugin-app-version), which is very similar.