### PR TITLE
Add support for bluebird and WinJS Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TODO: Write these instructions
 
 ## Use from Javascript
 
-If you are using jQuery or AngularJS, promise style is supported. Use something like:
+If you are using jQuery, AngularJS, WinJS or any Promise/A library (Bluebird), promise style is supported. Use something like:
 
     cordova.getAppVersion.getVersionNumber().then(function (version) {
         $('.version').text(version);

--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -8,17 +8,29 @@ var getPromisedCordovaExec = function (command, success, fail) {
   if (success === undefined) {
     if (window.jQuery) {
       deferred = jQuery.Deferred();
+      success = deferred.resolve;
+      fail = deferred.reject;
       toReturn = deferred;
     } else if (window.angular) {
       injector = angular.injector(["ng"]);
       $q = injector.get("$q");
       deferred = $q.defer();
+      success = deferred.resolve;
+      fail = deferred.reject;
       toReturn = deferred.promise;
+    } else if (window.Promise) {
+      toReturn = new Promise(function(c, e) {
+        success = c;
+        fail = e;
+      });
+    } else if (window.WinJS && window.WinJS.Promise) {
+      toReturn = new WinJS.Promise(function(c, e) {
+        success = c;
+        fail = e;
+      });
     } else {
-      return console.error('AppVersion either needs a success callback, or jQuery/AngularJS defined for using promises');
+      return console.error('AppVersion either needs a success callback, or jQuery/AngularJS/Promise/WinJS.Promise defined for using promises');
     }
-    success = deferred.resolve;
-    fail = deferred.reject;
   }
   // 5th param is NOT optional. must be at least empty array
   cordova.exec(success, fail, "AppVersion", command, []);


### PR DESCRIPTION
Users can now also use the promisified version of the plugin when they use ECMA5 script, bluebird or WinJS.Promise.