### PR TITLE
fix plugin.id in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="uk.co.whiteoctober.cordova.appversion"
+    id="cordova-plugin-app-version"
     version="0.1.7">
 
     <name>AppVersion</name>


### PR DESCRIPTION
Currently contains the old id, "uk.co.whiteoctober.cordova.appversion", which causes problems with plugin management with e.g. Ionic. Replaced with correct "cordova-plugin-app-version".