### PR TITLE
Adding function the get package Installer name

### DIFF
--- a/src/android/AppVersion.java
+++ b/src/android/AppVersion.java
@@ -35,6 +35,11 @@ public class AppVersion extends CordovaPlugin {
         callbackContext.success(packageManager.getPackageInfo(this.cordova.getActivity().getPackageName(), 0).versionCode);
       return true;
       }
+      if (action.equals("getInstaller")) {
+	      PackageManager packageManager = this.cordova.getActivity().getPackageManager();
+		    callbackContext.success(packageManager.getInstallerPackageName(this.cordova.getActivity().getPackageName()));
+		    return true;
+	    }
       return false;
     } catch (NameNotFoundException e) {
       callbackContext.success("N/A");

--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -57,4 +57,8 @@ getAppVersion.getVersionCode = function (success, fail) {
   return getPromisedCordovaExec('getVersionCode', success, fail);
 };
 
+getAppVersion.getInstaller = function (success, fail) {
+  return getPromisedCordovaExec('getInstaller', success, fail);
+};
+
 module.exports = getAppVersion;


### PR DESCRIPTION
The new function will return the name of the Installer repository.
It will be null if installed from a downloaded apk, 'com.amazon.venezia' if installed from the Amazon app store, 'com.android.vending' for Google Play and so on.