### PR TITLE
add missing attribute for js-module tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <js-module src="www/AppVersionPlugin.js">
+    <js-module src="www/AppVersionPlugin.js" name="AppVersionPlugin">
        <clobbers target="cordova.getAppVersion" />
     </js-module>
 


### PR DESCRIPTION
was causing obscure bug during installation with older version of nodejs, as is the case when using meteor (uses its own version of node currently at v0.10.41 where the 'path' package doesn't have the 'parse' method (see error below):

=> Errors executing Cordova commands:

   While adding plugin cordova-plugin-app-version@0.1.8 to Cordova project:
   TypeError: Uh oh!
   Object [object Object] has no method 'parse'
   at handlers.js-module.install (/<meteor project>/.meteor/local/cordova-build/platforms/android/cordova/lib/pluginHandlers.js:142:66)


and the culprit code (last line falls back to parsing the src attribute for a name if name is not defined):

    'js-module': {
        install: function (obj, plugin, project, options) {
            // Copy the plugin's files into the www directory.
            var moduleSource = path.resolve(plugin.dir, obj.src);
            var moduleName = plugin.id + '.' + (obj.name || path.parse(obj.src).name);

Defining the name attribute just avoids this mess :-)