### PR TITLE
Upd: Normalize behaviour of getVersionNumber on windows.

### DIFF
--- a/src/windows/AppVersionProxy.js
+++ b/src/windows/AppVersionProxy.js
@@ -1,7 +1,7 @@
 AppVersionProxy = {
   getVersionNumber: function (successCallback, failCallback, args) {
     var version = Windows.ApplicationModel.Package.current.id.version;
-    successCallback([version.major, version.minor, version.build, version.revision].join('.'));
+    successCallback([version.major, version.minor, version.build].join('.'));
   },
   getAppName: function (successCallback, failCallback, args) {
     if(Windows.ApplicationModel.Package.current && Windows.ApplicationModel.Package.current.displayName){


### PR DESCRIPTION
The windows version returns `2.2.9.0`, whereas the iOS and android version limit it to `2.2.9`.
